### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Dennis Buis
 maintainer=Dennis Buis
 sentence=Library for an Arduino based webradio playing ICEcast streams
 paragraph=Library for an Arduino based webradio playing ICEcast streams
-category=radio
+category=Other
 url=https://github.com/DennisB66/Simple-WebServer-Library-for-Arduino
 architectures=*


### PR DESCRIPTION
The previous category value caused the warning:
```
WARNING: Category 'radio' in library Simple-WebRadio-Library-for-Arduino is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format